### PR TITLE
Add service to pull data from github repo's contributors end point  

### DIFF
--- a/src/app/components/contribute/contribute.component.css
+++ b/src/app/components/contribute/contribute.component.css
@@ -1,3 +1,23 @@
 .sub-heading {
     font-size: 16px;
-  }
+}
+
+.testimonials {
+  margin-top: 20px;    
+}
+
+.avatar{
+  /* width: 6em; */
+  display: block;
+}
+.avatar img {
+  width: 4em;
+}
+.avatar p {
+ font-size: small;
+}
+
+.img-circle {
+  border-radius: 50%;
+}
+           

--- a/src/app/components/contribute/contribute.component.html
+++ b/src/app/components/contribute/contribute.component.html
@@ -7,10 +7,12 @@
 </div>
 
 <div class="container">
-    <p>If you wish to contribute to this project, Head to the <a href="https://github.com/Sarthak-Mittal/ifsc">Github repository</a>.</p>
+    <p>If you wish to contribute to this project, Head to the <a href="https://github.com/Sarthak-Mittal/ifsc">Github
+            repository</a>.</p>
 
     <ul>
-        <li>Read the <a href="https://github.com/Sarthak-Mittal/ifsc/blob/master/CONTRIBUTING.md">contributor guidelines</a> of the project</li>
+        <li>Read the <a href="https://github.com/Sarthak-Mittal/ifsc/blob/master/CONTRIBUTING.md">contributor
+                guidelines</a> of the project</li>
         <li>Get the project running locally</li>
         <li>Leave a message on a task you'd like to work on</li>
         <li>Get to work!</li>
@@ -20,4 +22,45 @@
     <p> Report feedbacks and bugs <a href="https://github.com/Sarthak-Mittal/ifsc/issues">here</a>.</p>
     <hr>
     <p> Thanks to all the <a href="https://github.com/Sarthak-Mittal/ifsc/graphs/contributors">contributors</a>!</p>
+    <!--     
+    <div *ngFor="let contributor of contributors">
+        <div class="card" style="width: 18rem;">
+            <img class="card-img-top" src="{{contributor.avatar_url}}" alt="Card image cap">
+            <div class="card-body">
+              <h5 class="card-title">{{contributor.login}}</h5>              <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+              <a href="{{contributor.url}}" class="btn btn-primary">{{contributor.login}}</a>
+            </div>
+        </div>
+    </div> -->
+    <!-- <div class="card-deck my-card-deck" *ngFor="let contributor of contributors">
+        <div class="card my-card">
+          <img class="card-img-top" src="{{contributor.avatar_url}}" alt="{{contributor.login}}">
+          <div class="card-body">
+            <p class="card-text"><small class="text-muted">{{contributor.login}}</small></p>
+          </div>
+        </div>
+      </div> -->
+
+    <!-- <div class="container">
+        <div class="row col-md-5 widget">
+            <div class="widget-content">
+                <ul class="widget-user-list" *ngFor="let contributor of contributors">
+                    <li><a href="#"><img src="{{contributor.avatar_url}}" alt=""></a></li>
+                </ul>
+            </div>
+        </div>
+    </div> -->
+
+
+
+    <div class="container testimonials">
+        <div class="row">
+            <div class="avatar col-4 col-sm-3 col-md-2  text-center" *ngFor="let contributor of contributors">
+                <a href="{{contributor.html_url}}">
+                    <img class="img-circle" src="{{contributor.avatar_url}}" alt="{{contributor.login}}">
+                </a>
+                <p class="text-center"><a href="{{contributor.html_url}}">{{contributor.login}}</a></p>
+            </div>
+        </div>
+    </div>
 </div>

--- a/src/app/components/contribute/contribute.component.html
+++ b/src/app/components/contribute/contribute.component.html
@@ -19,40 +19,10 @@
     </ul>
 
     <hr>
-    <p> Report feedbacks and bugs <a href="https://github.com/Sarthak-Mittal/ifsc/issues">here</a>.</p>
+    <p> This project is open source. See something that's wrong or unclear? Report feedbacks and bugs <a href="https://github.com/Sarthak-Mittal/ifsc/issues">here</a>.</p>
     <hr>
     <p> Thanks to all the <a href="https://github.com/Sarthak-Mittal/ifsc/graphs/contributors">contributors</a>!</p>
-    <!--     
-    <div *ngFor="let contributor of contributors">
-        <div class="card" style="width: 18rem;">
-            <img class="card-img-top" src="{{contributor.avatar_url}}" alt="Card image cap">
-            <div class="card-body">
-              <h5 class="card-title">{{contributor.login}}</h5>              <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-              <a href="{{contributor.url}}" class="btn btn-primary">{{contributor.login}}</a>
-            </div>
-        </div>
-    </div> -->
-    <!-- <div class="card-deck my-card-deck" *ngFor="let contributor of contributors">
-        <div class="card my-card">
-          <img class="card-img-top" src="{{contributor.avatar_url}}" alt="{{contributor.login}}">
-          <div class="card-body">
-            <p class="card-text"><small class="text-muted">{{contributor.login}}</small></p>
-          </div>
-        </div>
-      </div> -->
-
-    <!-- <div class="container">
-        <div class="row col-md-5 widget">
-            <div class="widget-content">
-                <ul class="widget-user-list" *ngFor="let contributor of contributors">
-                    <li><a href="#"><img src="{{contributor.avatar_url}}" alt=""></a></li>
-                </ul>
-            </div>
-        </div>
-    </div> -->
-
-
-
+    
     <div class="container testimonials">
         <div class="row">
             <div class="avatar col-4 col-sm-3 col-md-2  text-center" *ngFor="let contributor of contributors">
@@ -63,4 +33,5 @@
             </div>
         </div>
     </div>
+
 </div>

--- a/src/app/components/contribute/contribute.component.ts
+++ b/src/app/components/contribute/contribute.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { Contributors } from 'src/app/model/contributors';
+import { GithubService } from 'src/app/services/github.service';
 
 @Component({
   selector: 'app-contribute',
@@ -7,9 +9,19 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ContributeComponent implements OnInit {
 
-  constructor() { }
+  contributors : Contributors;
+
+  constructor(private githubService: GithubService) { }
 
   ngOnInit(): void {
+    this.githubService.getContributors().subscribe(
+      (data: Contributors) => {
+        this.contributors = data;
+      },
+      (error) => {
+        console.log(error);
+      }
+    );
   }
 
 }

--- a/src/app/model/contributors.ts
+++ b/src/app/model/contributors.ts
@@ -1,0 +1,21 @@
+export class Contributors {
+    login: string;
+    id: string;
+    node_id: string;
+    avatar_url: string;
+    gravatar_id: string;
+    url: string;
+    html_url: string;
+    followers_url: string;
+    following_url: string;
+    gists_url: string;
+    starred_url: string;
+    subscriptions_url: string;
+    organizations_url: string;
+    repos_url: string;
+    events_url: string;
+    received_events_url: string;
+    type: string;
+    site_admin: string;
+    contributions: number;
+  }

--- a/src/app/services/github.service.spec.ts
+++ b/src/app/services/github.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GithubService } from './github.service';
+
+describe('GithubService', () => {
+  let service: GithubService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GithubService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/github.service.ts
+++ b/src/app/services/github.service.ts
@@ -1,0 +1,19 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Contributors } from '../model/contributors';
+
+const BASE_URL: string = "https://api.github.com/repos/sarthak-mittal/ifsc/contributors";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GithubService {
+
+  constructor(private http: HttpClient) { }
+
+  getContributors(url: string = BASE_URL): Observable<Contributors>{
+    return this.http.get<Contributors>(url)
+  }
+
+}


### PR DESCRIPTION
- This will render dynamic data on the contributor's page. 
- The added service will fetch data from Github end-point API for repo's contributors. 
- Now a list of all the contributors will be populated with their avatar and handle with a link to their Github profile.
