### PR TITLE
bug fix: input data casing not as per regex casing

### DIFF
--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -24,7 +24,7 @@ export class HomeComponent {
   constructor(private bankService: BankService) {}
 
   submit() {
-    const ifscCode = this.bank.controls['ifsc'].value;
+    let ifscCode = this.bank.controls['ifsc'].value.toUpperCase();
     console.log('ifsc::', ifscCode);
     let ifscRegex = new RegExp("^[A-Z]{4}0[A-Z0-9]{6}$");
     let isValidIfsc = ifscRegex.test(ifscCode);


### PR DESCRIPTION
When typing IFSC in input field, it is uppercase but in backend it was lowercase. So it was always showing as invalid input since it was not passing the regex pattern.

Error case:
 - icic0000816

Success case:
- ICIC0000816